### PR TITLE
add gitpod compatibility note

### DIFF
--- a/exercises/codec-server/README.md
+++ b/exercises/codec-server/README.md
@@ -8,6 +8,9 @@ During this exercise, you will:
 - Integrate your Codec Server with the Temporal Web UI
 - Securely return decoded results in the CLI and the Web UI
 
+**Note: Part B of this Exercise does not work in the Gitpod Environment.**
+If you want to demonstrate Codec Server Web UI integration, you'll need to clone this repository and run the exercise locally.
+
 Make your changes to the code in the `practice` subdirectory (look for
 `TODO` comments that will guide you to where you should make changes to
 the code). If you need a hint or want to verify your changes, look at


### PR DESCRIPTION
Just spent about 3 hours looking into this Gitpod compatibility note: https://www.gitpod.io/docs/configure/workspaces/ports#cross-origin-resource-sharing-cors (including building a custom out of tree temporal CLI) and after all that I don't think we can get the Temporal Web UI's CORS implementation working in Gitpod for now.